### PR TITLE
updates for latest dVRK devel branches

### DIFF
--- a/code/mtsDerivedIntuitiveResearchKitPSM.cpp
+++ b/code/mtsDerivedIntuitiveResearchKitPSM.cpp
@@ -185,11 +185,11 @@ void mtsDerivedIntuitiveResearchKitPSM::UpdateOptimizerKinematics()
     mController->SetKinematics(mGoalKinematics);
 }
 
-void mtsDerivedIntuitiveResearchKitPSM::ControlPositionCartesian()
+void mtsDerivedIntuitiveResearchKitPSM::control_servo_cp()
 {
     // run without constraint motion
     if (!mConstraintMotionEnabled){
-        BaseType::ControlPositionCartesian();
+        BaseType::control_servo_cp();
     }
     // constraint motion
     else{
@@ -202,7 +202,7 @@ void mtsDerivedIntuitiveResearchKitPSM::ControlPositionCartesian()
             nmrConstraintOptimizer::STATUS optimizerStatus = Solve(jointInc);
             if (optimizerStatus == nmrConstraintOptimizer::STATUS::NMR_OK){
                 // finally send new joint values
-                SetPositionJointLocal(jointPosition+jointInc.Ref(mNumDof,0));
+                servo_jp_internal(jointPosition+jointInc.Ref(mNumDof,0));
             }
             else{
                 CMN_LOG_CLASS_RUN_ERROR << "Constraint optimization error: No solution found" << std::endl;
@@ -222,7 +222,7 @@ void mtsDerivedIntuitiveResearchKitPSM::GetRobotData()
     // add proxy position update
     if (IsJointReady() && IsCartesianReady() && m_new_pid_goal){
         mProxyCartesianPosition.SetTimestamp(m_kin_measured_js.Timestamp());
-        mProxyCartesianPosition.SetValid(BaseFrameValid);
+        mProxyCartesianPosition.SetValid(m_base_frame_valid);
         mProxyCartesianPosition.Position().From(CartesianSetParam.Goal());
 
         mProxyCaertesianTranslation.Assign(mProxyCartesianPosition.Position().Translation()).Multiply(cmn_m/cmn_mm);

--- a/code/mtsDerivedTeleOperationPSM.cpp
+++ b/code/mtsDerivedTeleOperationPSM.cpp
@@ -81,7 +81,7 @@ void mtsDerivedTeleOperationPSM::Configure(const std::string & CMN_UNUSED(filena
                               MTS_OPTIONAL);
 
     // ignore jaw
-    m_ignore_jaw = true;
+    m_jaw.ignore = true;
 
     // lock rotation
     m_rotation_locked = true;

--- a/code/mtsDerivedTeleOperationPSM.cpp
+++ b/code/mtsDerivedTeleOperationPSM.cpp
@@ -64,7 +64,7 @@ void mtsDerivedTeleOperationPSM::Configure(const std::string & CMN_UNUSED(filena
     // Add a required function
     interfacePSM->AddFunction("body/measured_cf",
                               PSMGetWrenchBody);
-    interfacePSM->AddFunction("SetWrenchBodyOrientationAbsolute",
+    interfacePSM->AddFunction("body/set_cf_orientation_absolute",
                               PSMSetWrenchBodyOrientationAbsolute);
     interfacePSM->AddFunction("measured_cv",
                               PSMGetVelocityCartesian);
@@ -81,13 +81,13 @@ void mtsDerivedTeleOperationPSM::Configure(const std::string & CMN_UNUSED(filena
                               MTS_OPTIONAL);
 
     // ignore jaw
-    mIgnoreJaw = true;
+    m_ignore_jaw = true;
 
     // lock rotation
-    mRotationLocked = true;
+    m_rotation_locked = true;
 
     // skip aligning MTM
-    mAlignMTM = false;
+    m_align_mtm = false;
 
     elasticityGain.Assign(1.0,1.0,1.0).Multiply(150.0);
 }
@@ -107,29 +107,29 @@ void mtsDerivedTeleOperationPSM::RunEnabled(void)
     BaseType::RunEnabled();
 
     // Use proxy location to set haptics feedback; Only if the PSM is following
-    if (mMTM.PositionCartesianCurrent.Valid()
-           && mPSM.PositionCartesianCurrent.Valid())
+    if (mMTM.m_measured_cp.Valid()
+           && mPSM.m_setpoint_cp.Valid())
     {
-        if (!mIsClutched && mIsFollowing){
+        if (!m_clutched && m_following){
             // compute mtm Cartesian motion
-            vctFrm4x4 mtmPosition(mMTM.PositionCartesianCurrent.Position());
+            vctFrm4x4 mtmPosition(mMTM.m_measured_cp.Position());
 
             // translation
             vct3 mtmTranslation;
             vct3 psmTranslation;
-            if (mTranslationLocked) {
+            if (m_translation_locked) {
                 psmTranslation = mPSM.CartesianInitial.Translation();
             } else {
                 mtmTranslation = (mtmPosition.Translation() - mMTM.CartesianInitial.Translation());
-                psmTranslation = mtmTranslation * mScale;
-                psmTranslation = mRegistrationRotation * psmTranslation + mPSM.CartesianInitial.Translation();
+                psmTranslation = mtmTranslation * m_scale;
+                psmTranslation = m_registration_rotation * psmTranslation + mPSM.CartesianInitial.Translation();
             }
             // rotation
             vctMatRot3 psmRotation;
-            if (mRotationLocked) {
+            if (m_rotation_locked) {
                 psmRotation.From(mPSM.CartesianInitial.Rotation());
             } else {
-                psmRotation = mRegistrationRotation * mtmPosition.Rotation() * mAlignOffsetInitial;
+                psmRotation = m_registration_rotation * mtmPosition.Rotation() * m_alignment_offset_initial;
             }
 
             vctFrm4x4 psmCartesianGoal;
@@ -138,7 +138,7 @@ void mtsDerivedTeleOperationPSM::RunEnabled(void)
 
             // proxy force
             prmPositionCartesianGet psmMeasuredCartesian;
-            mPSM.measured_cp(psmMeasuredCartesian);
+            mPSM.setpoint_cp(psmMeasuredCartesian);
             vct3 diff = psmMeasuredCartesian.Position().Translation() - psmCartesianGoal.Translation();
             vct3 force;
             for (size_t i=0 ; i < 3; i++){
@@ -146,7 +146,7 @@ void mtsDerivedTeleOperationPSM::RunEnabled(void)
             }
 
             // Re-orient based on rotation between MTM and PSM
-            force = mRegistrationRotation.Inverse() * force;
+            force = m_registration_rotation.Inverse() * force;
             // set force to MTM
             bool psmSimulated;
             PSMGetSimulation(psmSimulated);

--- a/include/mtsDerivedIntuitiveResearchKitPSM.h
+++ b/include/mtsDerivedIntuitiveResearchKitPSM.h
@@ -46,7 +46,7 @@ public:
 
 protected:
     // function override
-    void ControlPositionCartesian() override;
+    void control_servo_cp() override;
     void GetRobotData() override;
 
     // constraint controller

--- a/share/console-MTML-PSM2Derived_KIN_SIMULATED-TeleopDerived.json
+++ b/share/console-MTML-PSM2Derived_KIN_SIMULATED-TeleopDerived.json
@@ -1,0 +1,117 @@
+/* -*- Mode: Javascript; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+{
+    "component-manager": {
+        "components":
+        [
+            // this is to use our derived Teleop PSM, the name must
+            // match the name the console would use,
+            // i.e. <master>-<slave>
+            {
+                "shared-library": "dvrk_mesh_vf",
+                "class-name": "mtsDerivedTeleOperationPSM",
+                "constructor-arg": {
+                    "Name": "MTML-PSM2",
+                    "Period": 0.001
+                }
+            },
+            {
+                "shared-library": "dvrk_mesh_vf",
+                "class-name": "mtsDerivedIntuitiveResearchKitPSM",
+                "constructor-arg": {
+                    "Name": "PSM2",
+                    "Period": 0.001
+                }
+            }
+            ,
+            {
+                "shared-library": "dvrk_mesh_vf",
+                "class-name": "mtsDerivedROSBridge",
+                "constructor-arg": {
+                    "Name": "ros-Bridge",
+                    "Period": 0.1
+                },
+                "configure-parameter": "rosBridge.json"
+            }
+            ,
+            {
+                "shared-library": "dvrk_mesh_vf",
+                "class-name": "mtsDerivedIGTLBridge",
+                "constructor-arg": {
+                    "Name": "igtl-Bridge",
+                    "Period": 0.1
+                },
+                "configure-parameter": "igtlBridge.json"
+            }
+        ],
+        "connections":
+        [
+            {
+                "required":{
+                    "component": "ros-Bridge",
+                    "interface": "requiresPSM2"
+                },
+                "provided":{
+                    "component": "PSM2",
+                    "interface": "providesPSM2"
+                }
+            },
+            {
+                "required":{
+                    "component": "igtl-Bridge",
+                    "interface": "requiresPSM2"
+                },
+                "provided":{
+                    "component": "PSM2",
+                    "interface": "providesPSM2"
+                }
+            }
+        ]
+    }
+    ,
+    "io":
+    {
+        "footpedals": "io/sawRobotIO1394-MTML-foot-pedals.xml"
+    }
+    ,
+    "arms":
+    [
+        {
+            "name": "MTML",
+            "type": "MTM",
+            "system": "jhu-dVRK",
+            "serial": "22723",
+            "base-frame": {
+                "reference-frame": "HRSV",
+                "transform": [[ -1.0,  0.0,          0.0,          0.180],
+                              [  0.0,  0.866025404,  0.5,          0.400],
+                              [  0.0,  0.5,         -0.866025404,  0.475],
+                              [  0.0,  0.0,          0.0,          1.0]]
+            }
+        }
+        ,
+        {
+            "name": "PSM2",
+            "type": "PSM_DERIVED",
+            "simulation": "KINEMATIC",
+            "arm": "arm/PSM_KIN_SIMULATED_LARGE_NEEDLE_DRIVER_400006.json",
+            "base-frame": {
+                "reference-frame": "ECM",
+                "transform": [[  1.0,  0.0,          0.0,          0.20],
+                              [  0.0, -0.866025404,  0.5,          0.0 ],
+                              [  0.0, -0.5,         -0.866025404,  0.0 ],
+                              [  0.0,  0.0,          0.0,          1.0 ]]
+            }
+        }
+    ]
+    ,
+    "psm-teleops":
+    [
+        {
+            // this is where we tell the console to use our manually
+            // loaded teleop, using "type"
+            "type": "TELEOP_PSM_DERIVED",
+            "mtm": "MTML",
+            "psm": "PSM2"
+        }
+    ]
+}


### PR DESCRIPTION
@mli0603, I've updated the dVRK core code so internal commands and variables match more closely the ROS topics.  This is mostly switching from CamelCase to _snake_ .  There is one significant change, i.e. the teleoperation component should use the PSM `setpoint_cp`, not `measured_cp` to compute increments in cartesian positions sent using `servo_cp`.

For this repository, I renamed the data members from the base class and updated the _cisstMultiTask_ commands.  I didn't rename the variables in the derived teleop to match the CRTK names so the code might be a bit confusing now (e.g. https://github.com/adeguet1/PolygonMeshVirtualFixture/commit/3a18b28172b6122cde165d5cfb904c8dbc631602#diff-fe73fb4d3de45936223b8ad7e4eced470eab872feb5b4f2a864b8bf7474c33aaL141, `psmMeasuredCartesian` should probably be renamed `psm_setpoint_cf`).


I did test with PSM simulated and real MTM and everything seems to work.